### PR TITLE
Feat: graphql integration with fern-reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,9 +33,9 @@ function App() {
                                 routerProvider={routerBindings}
                                 resources={[
                                     {
-                                        name: "testruns",
-                                        list: "/testruns",
-                                        show: "/testruns/show/:id",
+                                        name: "testrun",
+                                        list: "/query",
+                                        show: "/query/show/:id",
                                     },
                                 ]}
                                 options={{
@@ -63,9 +63,9 @@ function App() {
                                         )}
                                     >
                                         <Route index element={
-                                            <NavigateToResource resource="testruns"/>
+                                            <NavigateToResource resource="testrun"/>
                                         }/>
-                                        <Route path="/testruns">
+                                        <Route path="/query">
                                             <Route index element={<TestRunsList/>}/>
                                             <Route path="show/:id" element={<TestRunShow/>}/>
                                         </Route>

--- a/src/pages/test-runs/list.tsx
+++ b/src/pages/test-runs/list.tsx
@@ -1,57 +1,122 @@
-import {List, useTable,} from "@refinedev/antd";
-import {Space, Table, Tag} from "antd";
-import React from "react";
+import { List, useTable } from "@refinedev/antd";
+import { Table, Spin } from "antd";
+import React, { useState } from "react";
 import moment from "moment";
-
+import axios from "axios";
 
 export const TestRunsList = () => {
-    const {tableProps} = useTable({
-        resource: "testruns/",
+    const { tableProps } = useTable({
+        resource: "testrun/",
     });
 
     const calculateDuration = (start: moment.MomentInput, end: moment.MomentInput) => {
         const duration = moment(end).diff(moment(start));
-        return moment.duration(duration).humanize();
+        return moment.duration(duration).asMilliseconds();
+    };
+
+    const API_URL = "http://localhost:8080";
+    const GRAPHQL_QUERY_URL = API_URL + "/query";
+    const [expandedRowKeys, setExpandedRowKeys] = useState([]);
+    const [expandedData, setExpandedData] = useState({});
+    const [loading, setLoading] = useState({});
+
+    const fetchExpandedData = async (testRunId) => {
+        setLoading((prev) => ({ ...prev, [testRunId]: true }));
+        try {
+            const testRunByIdQuery = `
+                query testRunById {
+                  testRunById(id: ${testRunId}) {
+                    id
+                    testProjectName
+                    testSeed
+                    startTime
+                    endTime
+                    suiteRuns {
+                      suiteName
+                      specRuns {
+                        id
+                        specDescription
+                        status
+                        startTime
+                        endTime
+                        message
+                      }
+                    }
+                  }
+                }`;
+
+            const response = await axios.post(GRAPHQL_QUERY_URL, {
+                query: testRunByIdQuery,
+            });
+
+            setExpandedData((prevData) => ({
+                ...prevData,
+                [testRunId]: response.data.data.testRunById,
+            }));
+        } catch (error) {
+            console.error("Failed to fetch expanded data:", error);
+        } finally {
+            setLoading((prev) => ({ ...prev, [testRunId]: false }));
+        }
+    };
+
+    const handleExpand = (expanded, record) => {
+        if (expanded) {
+            setExpandedRowKeys((prevKeys) => [...prevKeys, record.id]);
+            if (!expandedData[record.id]) {
+                fetchExpandedData(record.id);
+            }
+        } else {
+            setExpandedRowKeys((prevKeys) =>
+                prevKeys.filter((key) => key !== record.id)
+            );
+        }
     };
 
     return (
         <List>
-            <Table {...tableProps} rowKey="id" expandable={{
-                expandedRowRender(testRun) {
-                    return console.log(testRun),
-                        <>
-                            {testRun.suite_runs.map((suiteRun: { spec_runs: any[]; }, suiteIndex: any) => (
-                                suiteRun.spec_runs.map((specRun, specIndex) => (
-                                    <Table key={`suite-${suiteIndex}-spec-${specIndex}`}>
-                                        <Table.Column title="Test Run ID" dataIndex="id"
-                                                      render={() => specRun.id}/>
-                                        <Table.Column title="Project Name" dataIndex="test_project_name"
-                                                      render={() => testRun.test_project_name}/>
-                                        <Table.Column title="Description" dataIndex="spec_description"
-                                                      render={() => specRun.spec_description}/>
-                                        <Table.Column title="Status" dataIndex="status" render={(specRun.status)}/>
-                                        <Table.Column title="Duration"
-                                                      render={() => calculateDuration(specRun.start_time, specRun.end_time)}/>
-                                        {/*<Table.Column title="Tags" dataIndex="tags" render={() => (*/}
-                                        {/*    <Space>*/}
-                                        {/*        {specRun.tags.map((tag, tagIndex) => (*/}
-                                        {/*            <Tag key={tagIndex}>{tag.name}</Tag>*/}
-                                        {/*        ))}*/}
-                                        {/*    </Space>*/}
-                                        {/*)}/>*/}
-                                        <Table.Column title="Message" render={() => specRun.message}/>
-                                    </Table>
-                                ))
-                            ))}
-                        </>;
-                }
-            }}>
-                <Table.Column title="ID" dataIndex="id"/>
-                <Table.Column title="Test Project Name" dataIndex="test_project_name"/>
-                <Table.Column title="Start Time" dataIndex="start_time"
-                              render={(text) => moment(text).format('LLL')}/>
-                <Table.Column title="End Time" dataIndex="end_time"
-                              render={(text) => moment(text).format('LLL')}/>
+            <Table
+                {...tableProps}
+                rowKey="id"
+                expandable={{
+                    expandedRowKeys,
+                    onExpand: handleExpand,
+                    expandedRowRender: (record) => {
+                        const suiteRuns = expandedData[record.id]?.suiteRuns;
+                        if (loading[record.id] || !suiteRuns) {
+                            return <Spin />;
+                        }
+                        return (
+                            <>
+                                {suiteRuns.map((suiteRun, suiteIndex) => (
+                                    <div key={`suite-${suiteIndex}`}>
+                                        <h4>Suite: {suiteRun.suiteName}</h4>
+                                        <Table
+                                            dataSource={suiteRun.specRuns}
+                                            pagination={false}
+                                            rowKey={(specRun) => `spec-${specRun.id}`}
+                                        >
+                                            <Table.Column title="Spec Run ID" dataIndex="id" key="id" />
+                                            <Table.Column title="Description" dataIndex="specDescription" key="specDescription" />
+                                            <Table.Column title="Status" dataIndex="status" key="status" />
+                                            <Table.Column
+                                                title="Duration(ms)"
+                                                key="duration"
+                                                render={(text, specRun) => calculateDuration(specRun.startTime, specRun.endTime)}
+                                            />
+                                            <Table.Column title="Message" dataIndex="message" key="message" />
+                                        </Table>
+                                    </div>
+                                ))}
+                            </>
+                        );
+                    },
+                }}
+            >
+                <Table.Column title="ID" dataIndex="id" key="id" />
+                <Table.Column title="Test Project Name" dataIndex="testProjectName" key="testProjectName" />
+                <Table.Column title="Start Time" dataIndex="startTime" key="startTime" render={(text) => moment(text).format('LLL')} />
+                <Table.Column title="End Time" dataIndex="endTime" key="endTime" render={(text) => moment(text).format('LLL')} />
             </Table>
         </List>
     );


### PR DESCRIPTION
### FernUI Integration to fern-reporter via graphQL for HTTP GET requests.
1. This PR integrates with the code changes included in the fern-reporter PR[https://github.com/Guidewire/fern-reporter/pull/71](url)
2. We have 2 graphQl queries.
 a) testRunsQuery - fetches all testRuns (however this only fetches the parent testRun rows)
 b) testRunByIdQuery - fetches one testRun by Id (fetches testRun, suiteRuns and specRuns)