### PR TITLE
Feat: Display metadata information in the UI

### DIFF
--- a/src/mocks/mock-graphql-server.js
+++ b/src/mocks/mock-graphql-server.js
@@ -35,6 +35,10 @@ const typeDefs = `
     testSeed: Int
     startTime: String
     endTime: String
+    gitBranch: String
+    gitSha: String
+    buildTriggerActor: String
+    buildUrl: String
     suiteRuns: [SuiteRun!]!
   }
 
@@ -78,6 +82,17 @@ const generateMockData = () => {
     { id: 4, name: "Sanity" },
     { id: 5, name: "Performance" },
   ];
+  
+  const gitBranches = ["main", "develop", "feature/authentication", "bugfix/login-issue"];
+  const buildTriggerActors = ["alice", "bob", "charlie", "deploy-bot", "jenkins"];
+
+
+  // Utility function to generate a random Git SHA (40 characters)
+  const generateGitSha = () => 
+    Array.from({ length: 40 }, () => Math.floor(Math.random() * 16).toString(16)).join("");
+
+  // Generate a random build URL
+  const generateBuildUrl = (id) => `https://ci.example.com/build/${id}`;
 
   // Generate SpecRun
   const generateSpecRuns = (suiteId) =>
@@ -110,6 +125,10 @@ const generateMockData = () => {
     testSeed: Math.floor(Math.random() * 10000),
     startTime: `2025-01-01T09:00:00Z`,
     endTime: `2025-01-01T10:00:00Z`,
+    gitBranch: gitBranches[Math.floor(Math.random() * gitBranches.length)],
+    gitSha: generateGitSha(),
+    buildTriggerActor: buildTriggerActors[Math.floor(Math.random() * buildTriggerActors.length)],
+    buildUrl: generateBuildUrl(i + 1),
     suiteRuns: generateSuiteRuns(i + 1),
   }));
 };

--- a/src/pages/test-runs/graphQlQueries.ts
+++ b/src/pages/test-runs/graphQlQueries.ts
@@ -13,6 +13,10 @@ export const GET_TEST_RUNS = gql`
                     testSeed
                     startTime
                     endTime
+                    gitBranch
+                    gitSha
+                    buildTriggerActor
+                    buildUrl
                     suiteRuns {
                         id
                         suiteName
@@ -48,6 +52,10 @@ export const GET_TEST_RUN_BY_ID = gql`
             testSeed
             startTime
             endTime
+            gitBranch
+            gitSha
+            buildTriggerActor
+            buildUrl
             suiteRuns {
                 id
                 suiteName

--- a/src/pages/test-runs/interfaces.ts
+++ b/src/pages/test-runs/interfaces.ts
@@ -4,6 +4,10 @@ export interface ITestRun {
     testSeed: number;
     startTime: string;
     endTime: string;
+    gitBranch: string;
+    gitSha: string;
+    buildTriggerActor: string;
+    buildUrl: string;
     suiteRuns: ISuiteRun[];
 }
 

--- a/src/pages/test-runs/list.tsx
+++ b/src/pages/test-runs/list.tsx
@@ -11,6 +11,7 @@ import {
     uniqueTags,
     generateTagColor
 } from "./list-utils";
+import { Typography } from "antd/lib";
 
 const HEADER_NAME = import.meta.env.VITE_FERN_REPORTER_HEADER_NAME;
 
@@ -88,7 +89,7 @@ export const TestRunsList = () => {
                 <Table.Column
                     title="Status"
                     key="status"
-                    width={320}
+                    width={280}
                     render={(_text, testRun: ITestRun) => {
                         const statusMap = testRunsStatus(testRun);
                         return (
@@ -121,9 +122,9 @@ export const TestRunsList = () => {
                 />
                 <Table.Column title="Tags"
                               key="tags"
-                              width={500}
+                              width={280}
                               render={(_text, record: ITestRun) => (
-                                  <Space style={{minWidth: '200px'}}>
+                                  <Space wrap style={{minWidth: '200px'}}>
                                       {
                                           uniqueTags(record
                                               .suiteRuns
@@ -136,6 +137,52 @@ export const TestRunsList = () => {
                                       }
                                   </Space>
                               )}
+                />
+
+                <Table.Column
+                    title="Git Branch"
+                    key="gitBranch"
+                    render={(_text, testRun: ITestRun) => (
+                        <Typography.Paragraph 
+                            style={{color: 'inherit' }}>
+                                {testRun.gitBranch}
+                        </Typography.Paragraph>
+                    )}
+                />
+
+                <Table.Column
+                    title="Git SHA"
+                    key="gitSha"
+                    render={(_text, testRun: ITestRun) => (
+                        <Typography.Paragraph 
+                            style={{ color: 'inherit' }}>
+                                {testRun.gitSha}
+                        </Typography.Paragraph>
+                    )}
+                />
+
+                <Table.Column
+                    title="Build Trigger Actor"
+                    key="buildTriggerActor"
+                    render={(_text, testRun: ITestRun) =>
+                        <Typography.Paragraph 
+                            style={{ color: 'inherit' }}>
+                                {testRun.buildTriggerActor}
+                        </Typography.Paragraph>
+                    }
+                />
+
+                <Table.Column
+                    title="Build URL"
+                    key="buildUrl"
+                    render={(_text, testRun: ITestRun) =>
+                        <Typography.Link 
+                            style={{ color: '#66c2ff', textDecoration: 'underline' }}
+                            target="_blank"
+                            href={testRun.buildUrl}>
+                                {testRun.buildUrl}
+                        </Typography.Link>
+                    }
                 />
             </Table>
         </List>

--- a/src/providers/testrun-graphql-provider.ts
+++ b/src/providers/testrun-graphql-provider.ts
@@ -27,6 +27,10 @@ interface TestRun {
     testSeed: string;
     startTime: string;
     endTime: string;
+    gitBranch: string;
+    gitSha: string;
+    buildTriggerActor: string;
+    buildUrl: string;
     suiteRuns: {
         id: string;
         suiteName: string;

--- a/test/component/test-runs-list.test.tsx
+++ b/test/component/test-runs-list.test.tsx
@@ -67,6 +67,10 @@ describe("TestRunsList Component", () => {
                 ],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 
@@ -90,6 +94,10 @@ describe("TestRunsList Component", () => {
         expect(screen.getByText('Spec Runs')).toBeInTheDocument();
         expect(screen.getByText('Duration')).toBeInTheDocument();
         expect(screen.getByText('Tags')).toBeInTheDocument();
+        expect(screen.getByText('Git Branch')).toBeInTheDocument();
+        expect(screen.getByText('Git SHA')).toBeInTheDocument();
+        expect(screen.getByText('Build Trigger Actor')).toBeInTheDocument();
+        expect(screen.getByText('Build URL')).toBeInTheDocument();
     });
 
     it("should render loading state", () => {
@@ -134,6 +142,10 @@ describe("TestRunsList Component", () => {
                 suiteRuns: [{ suiteName: "Suite 1", specRuns: [] }],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 
@@ -153,6 +165,10 @@ describe("TestRunsList Component", () => {
         await waitFor(() => {
             expect(screen.getByText("Project A")).toBeInTheDocument();
             expect(screen.getByText("Suite 1")).toBeInTheDocument();
+            expect(screen.getByText("main")).toBeInTheDocument();
+            expect(screen.getByText("kf6830")).toBeInTheDocument();
+            expect(screen.getByText("user1")).toBeInTheDocument();
+            expect(screen.getByText("http://example.com/build/1")).toBeInTheDocument();
         });
     });
 
@@ -164,6 +180,10 @@ describe("TestRunsList Component", () => {
                 suiteRuns: [{ suiteName: "Suite 1", specRuns: [] }],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
         const fetchNextPageMock = jest.fn();
@@ -233,6 +253,10 @@ describe("TestRunsList Component", () => {
                 ],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 
@@ -295,6 +319,10 @@ describe("TestRunsList Component", () => {
                 ],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 
@@ -324,6 +352,10 @@ describe("TestRunsList Component", () => {
                 suiteRuns: [{ suiteName: "Suite 1", specRuns: [] }],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 
@@ -378,6 +410,10 @@ describe("TestRunsList Component", () => {
                 ],
                 startTime: "2022-01-01T00:00:00Z",
                 endTime: "2022-01-01T01:00:00Z",
+                gitBranch: "main",
+                gitSha: "kf6830",
+                buildTriggerActor: "user1",
+                buildUrl: "http://example.com/build/1",
             },
         ];
 

--- a/test/utils/dataMocks.ts
+++ b/test/utils/dataMocks.ts
@@ -22,6 +22,10 @@ const testRun: ITestRun = {
     "testSeed": 1717396142,
     "startTime": "2024-06-03T06:29:32.938772Z",
     "endTime": "2024-06-03T06:29:34.517009Z",
+    "gitBranch": "main",
+    "gitSha": "e1e7d6f",
+    "buildTriggerActor": "test-runner",
+    "buildUrl": "example.com",
     "suiteRuns": [
         {
             "id": 1,

--- a/test/utils/summaryDataMocks.ts
+++ b/test/utils/summaryDataMocks.ts
@@ -3,6 +3,7 @@ import {IReportSummary} from "../../src/pages/test-summaries/interfaces";
 export const reportSummary: IReportSummary = {
     StartTime: "2024-04-20T04:20:00.000000Z",
     SuiteRunID: 1,
+    SuiteName: "Dummy Suite",
     TestProjectName: "Dummy Project",
     TotalPassedSpecRuns: 3,
     TotalSkippedSpecRuns: 0,


### PR DESCRIPTION
As a part of #37 
- Added four new columns to the UI to display test meta information from `fern-reporter`:
    - **Git Branch**
    - **Git SHA**
    - **Build Trigger Actor**
    - **Build URL** - Implemented clickable links
- Integrated mock data for the new columns.
- Added relevant test cases for the changes.

As a part of #28
- Included it in this PR since it was a minor fix - added a `wrap` to display tags in the next line, once there is no space for tags in the first line


<img width="1714" alt="FernUI_Frontend" src="https://github.com/user-attachments/assets/280a58fe-63fc-4a54-8b49-9d14bcded8ea" />
