### PR TITLE
fix: navigates to test summaries when fern ui loads #46

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ function App() {
                                         )}
                                     >
                                         <Route index element={
-                                            <NavigateToResource resource="testruns"/>
+                                            <NavigateToResource resource="summaries"/>
                                         }/>
                                         <Route path="/testruns">
                                             <Route index element={<TestRunsList/>}/>


### PR DESCRIPTION
Navigates to test summaries when fern ui loads